### PR TITLE
Adafruit_CircuitPython_74HC595: Added support for multiple shift registers

### DIFF
--- a/adafruit_74hc595.py
+++ b/adafruit_74hc595.py
@@ -117,8 +117,6 @@ class ShiftRegister74HC595:
         self._device = spi_device.SPIDevice(spi, latch, baudrate=1000000)
         self._number_of_shift_registers = number_of_shift_registers
         self._gpio = bytearray(self._number_of_shift_registers)
-        for x in range(0, self._number_of_shift_registers - 1):
-            self._gpio[x] = 0x00
 
     @property
     def number_of_shift_registers(self):

--- a/adafruit_74hc595.py
+++ b/adafruit_74hc595.py
@@ -44,7 +44,7 @@ class DigitalInOut:
         ShiftRegister74HC595 instance.
         """
         self._pin = pin_number
-        self._byte_pos = int(self._pin / 8)
+        self._byte_pos = self._pin // 8
         self._byte_pin = self._pin % 8
         self._shift_register = shift_register_74hc595
 

--- a/adafruit_74hc595.py
+++ b/adafruit_74hc595.py
@@ -132,9 +132,7 @@ class ShiftRegister74HC595:
 
     @gpio.setter
     def gpio(self, val):
-
-        for x in range(0, self._number_of_shift_registers - 1):
-            self._gpio[x] = val[x] & 0xFF
+        self._gpio = val
 
         with self._device as spi:
             # pylint: disable=no-member

--- a/adafruit_74hc595.py
+++ b/adafruit_74hc595.py
@@ -44,6 +44,8 @@ class DigitalInOut:
         ShiftRegister74HC595 instance.
         """
         self._pin = pin_number
+        self._byte_pos = int(self._pin / 8)
+        self._byte_pin = self._pin % 8
         self._shift_register = shift_register_74hc595
 
     # kwargs in switch functions below are _necessary_ for compatibility
@@ -65,16 +67,23 @@ class DigitalInOut:
     @property
     def value(self):
         """The value of the pin, either True for high or False for low."""
-        return self._shift_register.gpio & (1 << self._pin) == (1 << self._pin)
+        return self._shift_register.gpio[self._byte_pos] & (1 << self._byte_pin) == (
+            1 << self._byte_pin
+        )
 
     @value.setter
     def value(self, val):
-        gpio = self._shift_register.gpio
-        if val:
-            gpio |= 1 << self._pin
-        else:
-            gpio &= ~(1 << self._pin)
-        self._shift_register.gpio = gpio
+
+        if (
+            self._pin >= 0
+            and self._pin < self._shift_register.number_of_shift_registers * 8
+        ):
+            gpio = self._shift_register.gpio
+            if val:
+                gpio[self._byte_pos] |= 1 << self._byte_pin
+            else:
+                gpio[self._byte_pos] &= ~(1 << self._byte_pin)
+            self._shift_register.gpio = gpio
 
     @property
     def direction(self):
@@ -100,23 +109,35 @@ class DigitalInOut:
 
 
 class ShiftRegister74HC595:
-    """Initialise the 74HC595 on specified SPI bus."""
+    """Initialise the 74HC595 on specified SPI bus
+    and indicate the number of shift registers being used
+    """
 
-    def __init__(self, spi, latch):
+    def __init__(self, spi, latch, number_of_shift_registers=1):
         self._device = spi_device.SPIDevice(spi, latch, baudrate=1000000)
-        self._gpio = bytearray(1)
-        self._gpio[0] = 0x00
+        self._number_of_shift_registers = number_of_shift_registers
+        self._gpio = bytearray(self._number_of_shift_registers)
+        for x in range(0, self._number_of_shift_registers - 1):
+            self._gpio[x] = 0x00
+
+    @property
+    def number_of_shift_registers(self):
+        """The number of shift register chips """
+        return self._number_of_shift_registers
 
     @property
     def gpio(self):
         """The raw GPIO output register.  Each bit represents the
         output value of the associated pin (0 = low, 1 = high).
         """
-        return self._gpio[0]
+        return self._gpio
 
     @gpio.setter
     def gpio(self, val):
-        self._gpio[0] = val & 0xFF
+
+        for x in range(0, self._number_of_shift_registers - 1):
+            self._gpio[x] = val[x] & 0xFF
+
         with self._device as spi:
             # pylint: disable=no-member
             spi.write(self._gpio)
@@ -125,5 +146,5 @@ class ShiftRegister74HC595:
         """Convenience function to create an instance of the DigitalInOut class
         pointing at the specified pin of this 74HC595 device .
         """
-        assert 0 <= pin <= 7
+        assert 0 <= pin <= (self._number_of_shift_registers * 8) - 1
         return DigitalInOut(pin, self)


### PR DESCRIPTION
I simply changed the single byte used to send to the shift register into an array. Then mapped pin values greater than 7 to the next byte.   So you will see value of _byte_pos which is the element of the byte array and _byte_pin which is the bit in the _byte_pos element.