### PR TITLE
python 3.7 for rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@
 version: 2
 
 python:
-  version: "3.6"
+  version: "3.7"
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt


### PR DESCRIPTION
This change updates the python version that Readthedocs system will use when building the documentation.